### PR TITLE
Add a bunch of parsing stuff and ReadText endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,8 @@ name = "alpha_sign"
 version = "0.1.0"
 dependencies = [
  "nom",
+ "num-derive",
+ "num-traits",
  "time",
 ]
 
@@ -753,6 +755,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "num-traits"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ The request body should be:
 }
 ```
 
+###  `GET /text/get/:label`
+e.g. `GET /text/get/A`
+
+Gets text from a given label from the sign. The response will be blank if the label does not contain text or is uninitialised.
+
+The response body should be:
+```json
+{
+    "text": "Text from the sign's memory"
+}
+```
+
+
 ## Building
 
 the backend is built the normal rust way with `cargo build`, if you want to crossbuild for the pi grab the aarch64-unknown-linux-gnu gcc toolchain and run `cargo build  --target aarch64-unknown-linux-gnu`.

--- a/alpha_sign/Cargo.toml
+++ b/alpha_sign/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 nom = "7.1.3"
 time = "0.3.36"
+num-derive = "0.4.2"
+num-traits = "0.2.18"

--- a/alpha_sign/src/lib.rs
+++ b/alpha_sign/src/lib.rs
@@ -110,7 +110,7 @@ impl Packet {
                     many_m_n(5, 100, char(0x00.into())),         // starting nulls
                     nom::character::complete::char(0x01.into()), // start of transmission
                 ),
-                many1(terminated(SignSelector::parse, opt(char(',')))), // selector, TODO support multiple selectors
+                many1(terminated(SignSelector::parse, opt(char(',')))),
             ),
             terminated(
                 many0(Command::parse),
@@ -151,7 +151,7 @@ impl Command {
             Command::WriteSpecial(_) => false,
         }
     }
-    // TODO add other command types in an `alt`
+
     pub fn parse(input: ParseInput) -> ParseResult<Self> {
         Ok(alt((
             map(text::WriteText::parse, |x| Command::WriteText(x)),
@@ -169,6 +169,7 @@ pub enum SignType {
     FullMatrixAlphaVision = 0x24,
     CharacterMatrixAlphaVision = 0x25,
     LineMatrixAlphaVision = 0x26,
+    ResponsePacket = 0x30,
     OneLineSign = 0x31,
     TwoLineSign = 0x32,
     AllSigns = 0x3f,

--- a/alpha_sign/src/lib.rs
+++ b/alpha_sign/src/lib.rs
@@ -1,10 +1,7 @@
 use nom::{
-    branch::alt,
     bytes::complete::take_while,
-    character::{
-        complete::{char, digit1},
-        is_hex_digit,
-    },
+    character::complete::char,
+    character::is_hex_digit,
     combinator::{map, map_opt, map_res, opt},
     multi::{many0, many1, many_m_n},
     number::complete::u8,
@@ -15,11 +12,6 @@ use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
 use std::str;
-
-use crate::{
-    text::{ReadText, WriteText},
-    write_special::WriteSpecial,
-};
 
 pub mod text;
 pub mod write_special;
@@ -161,7 +153,9 @@ impl Command {
     }
     // TODO add other command types in an `alt`
     pub fn parse(input: ParseInput) -> ParseResult<Self> {
-        Ok(map(WriteText::parse, |x| Command::WriteText(x))(input)?)
+        Ok(map(text::WriteText::parse, |x| Command::WriteText(x))(
+            input,
+        )?)
     }
 }
 
@@ -216,6 +210,3 @@ pub enum SignType {
     TemperatureProbe = 0x79,
     AllSignsWithMemoryConfiguredFor26Files = 0x7a,
 }
-
-#[cfg(test)]
-mod tests {}

--- a/alpha_sign/src/lib.rs
+++ b/alpha_sign/src/lib.rs
@@ -1,7 +1,7 @@
 use nom::{
+    branch::alt,
     bytes::complete::take_while,
-    character::complete::char,
-    character::is_hex_digit,
+    character::{complete::char, is_hex_digit},
     combinator::{map, map_opt, map_res, opt},
     multi::{many0, many1, many_m_n},
     number::complete::u8,
@@ -153,9 +153,10 @@ impl Command {
     }
     // TODO add other command types in an `alt`
     pub fn parse(input: ParseInput) -> ParseResult<Self> {
-        Ok(map(text::WriteText::parse, |x| Command::WriteText(x))(
-            input,
-        )?)
+        Ok(alt((
+            map(text::WriteText::parse, |x| Command::WriteText(x)),
+            map(text::ReadText::parse, |x| Command::ReadText(x)),
+        ))(input)?)
     }
 }
 

--- a/alpha_sign/src/lib.rs
+++ b/alpha_sign/src/lib.rs
@@ -22,7 +22,7 @@ pub type ParseResult<'a, O> =
 
 pub const BROADCAST: u8 = 0x00;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct SignSelector {
     pub sign_type: SignType,
     pub address: u8,
@@ -65,7 +65,7 @@ pub enum SignError {
     EncodingError(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Packet {
     pub selectors: Vec<SignSelector>,
     pub commands: Vec<Command>,
@@ -128,7 +128,7 @@ impl Packet {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Command {
     WriteText(text::WriteText),
     ReadText(text::ReadText),
@@ -160,7 +160,7 @@ impl Command {
 }
 
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, FromPrimitive)]
+#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq, Eq)]
 pub enum SignType {
     SignWithVisualVerification = 0x21,
     SerialClock = 0x22,

--- a/alpha_sign/src/lib.rs
+++ b/alpha_sign/src/lib.rs
@@ -2,13 +2,24 @@ pub mod text;
 pub mod write_special;
 
 pub type ParseInput<'a> = &'a [u8];
-pub type ParseResult<'a, O> = nom::IResult<ParseInput<'a>, O, nom::error::VerboseError<ParseInput<'a>>>;
+pub type ParseResult<'a, O> =
+    nom::IResult<ParseInput<'a>, O, nom::error::VerboseError<ParseInput<'a>>>;
 
 pub const BROADCAST: u8 = 0x00;
 
+#[derive(Copy, Clone)]
 pub struct SignSelector {
     pub sign_type: SignType,
     pub address: u8,
+}
+
+impl Default for SignSelector {
+    fn default() -> SignSelector {
+        SignSelector {
+            sign_type: SignType::All,
+            address: 0,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -18,22 +29,21 @@ pub enum SignError {
 
 pub struct Packet {
     pub selectors: Vec<SignSelector>,
-    pub commands: Vec<Command>
-
+    pub commands: Vec<Command>,
 }
 
 impl Packet {
     pub fn new(selectors: Vec<SignSelector>, commands: Vec<Command>) -> Self {
         //TODO maybe make this validate that read cant be not last
-        Self { 
+        Self {
             selectors,
-            commands
+            commands,
         }
     }
 
-    pub fn encode_multiple(&self) -> Result<Vec<u8>, SignError> {
+    pub fn encode(&self) -> Result<Vec<u8>, SignError> {
         let mut res: Vec<u8> = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x01]; //start of transmission
-        for selector in &self.selectors{
+        for selector in &self.selectors {
             res.push(selector.sign_type as u8);
             res.append(&mut format!("{address:0>2X}", address = selector.address).into_bytes());
         }
@@ -48,20 +58,14 @@ impl Packet {
             command_section.append(&mut format!("{sum:0>4X}").into_bytes());
             res.append(&mut command_section);
         }
-        if self.commands.len() == 1 {
-            res.pop(); // remove trailing 0x03 if it isn't needed (this breaks otherwise for some reason)
-        }
         res.push(0x04); //end of transmission
         Ok(res)
     }
 
-    pub fn decode(packet: ParseInput ) -> Result<Self, SignError> {
+    pub fn decode(packet: ParseInput) -> Result<Self, SignError> {
         todo!()
     }
-
 }
-
-
 
 pub enum Command {
     WriteText(text::WriteText),

--- a/alpha_sign/src/lib.rs
+++ b/alpha_sign/src/lib.rs
@@ -156,6 +156,9 @@ impl Command {
         Ok(alt((
             map(text::WriteText::parse, |x| Command::WriteText(x)),
             map(text::ReadText::parse, |x| Command::ReadText(x)),
+            map(write_special::WriteSpecial::parse, |x| {
+                Command::WriteSpecial(x)
+            }),
         ))(input)?)
     }
 }

--- a/alpha_sign/src/text.rs
+++ b/alpha_sign/src/text.rs
@@ -11,7 +11,6 @@ use nom::multi::count;
 use nom::sequence::delimited;
 use nom::sequence::pair;
 use nom::sequence::preceded;
-use nom::sequence::terminated;
 use nom::sequence::tuple;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -188,7 +187,7 @@ impl WriteText {
     const COMMANDCODE: u8 = 0x41;
 
     pub fn new(label: char, message: String) -> Self {
-        //TODO check lable is valid
+        //TODO check label is valid
         //TODO make a message type
         Self {
             label,
@@ -230,7 +229,7 @@ impl WriteText {
                 )), // text position and transition mode
                 map_res(take_while(|x| x >= 0x20), str::from_utf8), // message body
             )),
-            opt(preceded(char(0x03.into()), count(hex_digit0, 4))),
+            opt(preceded(char(0x03.into()), count(hex_digit0, 4))), // checksum, parsed but discarded
         )(input)?;
 
         let mut w = WriteText::new(parse.0, parse.2.to_string());
@@ -262,7 +261,7 @@ impl ReadText {
         let (remain, parse) = delimited(
             tag([0x02, Self::COMMANDCODE]),
             anychar,                                                // label
-            opt(preceded(char(0x03.into()), count(hex_digit0, 4))), // optional checksum
+            opt(preceded(char(0x03.into()), count(hex_digit0, 4))), // optional checksum, discarded
         )(input)?;
 
         Ok((remain, ReadText::new(parse)))

--- a/alpha_sign/src/text.rs
+++ b/alpha_sign/src/text.rs
@@ -175,7 +175,7 @@ impl TransitionMode {
 }
 
 // parses any number of ASCII printable characters
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct WriteText {
     pub label: char,
     pub message: String,
@@ -244,7 +244,7 @@ impl WriteText {
         Ok((remain, w))
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ReadText {
     pub label: char,
 }

--- a/alpha_sign/src/text.rs
+++ b/alpha_sign/src/text.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[repr(u8)]
 pub enum TextPosition {
     MiddleLine = 0x20,
@@ -9,7 +9,7 @@ pub enum TextPosition {
     Right = 0x32,
 }
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum TransitionMode {
     Rotate,
     Hold,
@@ -86,6 +86,7 @@ impl Into<Vec<u8>> for TransitionMode {
     }
 }
 
+#[derive(Debug)]
 pub struct WriteText {
     pub label: char,
     pub message: String,
@@ -127,7 +128,7 @@ impl WriteText {
         res
     }
 }
-
+#[derive(Debug)]
 pub struct ReadText {
     pub label: char,
 }

--- a/alpha_sign/src/text.rs
+++ b/alpha_sign/src/text.rs
@@ -1,4 +1,28 @@
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::bytes::complete::take_while;
+use nom::character::complete::anychar;
+use nom::character::complete::char;
+use nom::character::complete::hex_digit0;
+use nom::character::complete::one_of;
+use nom::combinator::map;
+use nom::combinator::map_opt;
+use nom::combinator::map_res;
+use nom::combinator::opt;
+use nom::multi::count;
+use nom::multi::many_m_n;
+use nom::sequence::pair;
+use nom::sequence::preceded;
+use nom::sequence::terminated;
+use nom::sequence::tuple;
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use std::str;
+
+use crate::ParseInput;
+use crate::ParseResult;
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug, FromPrimitive)]
 #[repr(u8)]
 pub enum TextPosition {
     MiddleLine = 0x20,
@@ -86,6 +110,67 @@ impl Into<Vec<u8>> for TransitionMode {
     }
 }
 
+impl From<Vec<u8>> for TransitionMode {
+    fn from(input: Vec<u8>) -> Self {
+        let modes = [
+            TransitionMode::Rotate,
+            TransitionMode::Hold,
+            TransitionMode::Flash,
+            TransitionMode::RollUp,
+            TransitionMode::RollDown,
+            TransitionMode::RollLeft,
+            TransitionMode::RollRight,
+            TransitionMode::WipeUp,
+            TransitionMode::WipeDown,
+            TransitionMode::WipeLeft,
+            TransitionMode::WipeRight,
+            TransitionMode::Scroll,
+            TransitionMode::AutoMode,
+            TransitionMode::RollIn,
+            TransitionMode::RollOut,
+            TransitionMode::WipeIn,
+            TransitionMode::WipeOut,
+            TransitionMode::CompressedRotate,
+            TransitionMode::Explode,
+            TransitionMode::Clock,
+            TransitionMode::Twinkle,
+            TransitionMode::Sparkle,
+            TransitionMode::Snow,
+            TransitionMode::Interlock,
+            TransitionMode::Switch,
+            TransitionMode::Slide,
+            TransitionMode::Spray,
+            TransitionMode::Starburst,
+            TransitionMode::Welcome,
+            TransitionMode::SlotMachine,
+            TransitionMode::NewsFlash,
+            TransitionMode::TrumpetAnimation,
+            TransitionMode::CycleColors,
+        ];
+
+        for m in modes {
+            let val: Vec<u8> = m.into();
+            if input.as_slice() == val.as_slice() {
+                return m;
+            }
+        }
+        TransitionMode::AutoMode
+    }
+}
+
+impl TransitionMode {
+    pub fn parse(input: ParseInput) -> ParseResult<Self> {
+        let (remain, parse) = pair(anychar, opt(anychar))(input)?;
+
+        let mut code: Vec<u8> = vec![parse.0 as u8];
+        if let Some(second) = parse.1 {
+            code.push(second as u8)
+        }
+        Ok((remain, TransitionMode::from(code)))
+    }
+}
+
+// parses any number of ASCII printable characters
 #[derive(Debug)]
 pub struct WriteText {
     pub label: char,
@@ -121,11 +206,43 @@ impl WriteText {
         let mut res = vec![Self::COMMANDCODE, self.label as u8];
 
         if self.position != TextPosition::MiddleLine || self.mode != TransitionMode::AutoMode {
+            res.push(0x1b);
             res.push(self.position as u8);
             res.append(&mut self.mode.into());
         }
         res.extend_from_slice(self.message.as_bytes().into());
         res
+    }
+
+    pub fn parse(input: ParseInput) -> ParseResult<Self> {
+        let (remain, parse) = preceded(
+            tag([0x02, Self::COMMANDCODE]), // command codea
+            terminated(
+                tuple((
+                    anychar, // label, TODO label parser
+                    opt(preceded(
+                        char(0x1b.into()),
+                        pair(
+                            map_opt(one_of([0x20, 0x22, 0x26, 0x30, 0x31, 0x32]), |x| {
+                                TextPosition::from_u8(x as u8)
+                            }),
+                            TransitionMode::parse,
+                        ),
+                    )), // text position and transition mode
+                    map_res(take_while(|x| x >= 0x20), str::from_utf8), // message body
+                )),
+                opt(preceded(char(0x03.into()), count(hex_digit0, 4))), // checksum
+            ), // optional checksum
+        )(input)?;
+
+        let mut w = WriteText::new(parse.0, parse.2.to_string());
+
+        if let Some((position, mode)) = parse.1 {
+            w.position = position;
+            w.mode = mode;
+        }
+
+        Ok((remain, w))
     }
 }
 #[derive(Debug)]
@@ -141,5 +258,9 @@ impl ReadText {
 
     pub fn encode(&self) -> Vec<u8> {
         vec![Self::COMMANDCODE, self.label as u8]
+    }
+
+    pub fn parse(input: ParseInput) -> ParseResult<Self> {
+        todo!()
     }
 }

--- a/alpha_sign/src/text.rs
+++ b/alpha_sign/src/text.rs
@@ -260,6 +260,14 @@ impl ReadText {
     }
 
     pub fn parse(input: ParseInput) -> ParseResult<Self> {
-        todo!()
+        let (remain, parse) = preceded(
+            tag([0x02, Self::COMMANDCODE]),
+            terminated(
+                anychar,                                                // label
+                opt(preceded(char(0x03.into()), count(hex_digit0, 4))), // optional checksum
+            ),
+        )(input)?;
+
+        Ok((remain, ReadText::new(parse)))
     }
 }

--- a/alpha_sign/src/text.rs
+++ b/alpha_sign/src/text.rs
@@ -1,16 +1,13 @@
-use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::bytes::complete::take_while;
 use nom::character::complete::anychar;
 use nom::character::complete::char;
 use nom::character::complete::hex_digit0;
 use nom::character::complete::one_of;
-use nom::combinator::map;
 use nom::combinator::map_opt;
 use nom::combinator::map_res;
 use nom::combinator::opt;
 use nom::multi::count;
-use nom::multi::many_m_n;
 use nom::sequence::pair;
 use nom::sequence::preceded;
 use nom::sequence::terminated;

--- a/alpha_sign/src/write_special.rs
+++ b/alpha_sign/src/write_special.rs
@@ -3,7 +3,7 @@ use time::Time;
 use crate::ParseInput;
 use crate::ParseResult;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum WriteSpecial {
     SetTime(SetTime),
     ToggleSpeaker(ToggleSpeaker),
@@ -40,7 +40,7 @@ impl WriteSpecial {
         todo!()
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SetTime {
     pub time: Time,
 }
@@ -61,7 +61,7 @@ impl SetTime {
         res
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ToggleSpeaker {
     pub enabled: bool,
 }
@@ -85,13 +85,13 @@ impl ToggleSpeaker {
         res
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ColorStatus {
     Monochrome,
     Tricolor,
     Octocolor,
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct StartStopTime {
     time: Time,
 }
@@ -106,7 +106,7 @@ impl StartStopTime {
         self.time
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum OnPeriod {
     Always,
     Never,
@@ -134,13 +134,13 @@ impl OnPeriod {
         format!("{start:0<2X}{end:0<2X}", start = res[0], end = res[1]).into_bytes()
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum FileType {
     Text { on_period: OnPeriod },
     String,
     Dots { color_status: ColorStatus },
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MemoryConfiguration {
     pub label: char,
     pub file_type: FileType,
@@ -185,7 +185,7 @@ impl MemoryConfiguration {
         res
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ConfigureMemory {
     pub configurations: Vec<MemoryConfiguration>,
 }
@@ -207,7 +207,7 @@ impl ConfigureMemory {
         res
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ClearMemoryAndFlash {}
 
 impl ClearMemoryAndFlash {
@@ -221,7 +221,7 @@ impl ClearMemoryAndFlash {
         Self::SPECIAL_LABEL.into()
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SetDayOfWeek {
     pub day: time::Weekday,
 }
@@ -248,7 +248,7 @@ impl SetDayOfWeek {
         res
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SetTimeFormat {
     pub twenty_four_hour: bool,
 }
@@ -272,13 +272,13 @@ impl SetTimeFormat {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ToneError {
     DurationOutOfRange,
     RepeatsOutOfRange,
     FrequencyOutOfRange,
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ProgrammmableTone {
     frequency: u8,
     duration: u8,
@@ -328,7 +328,7 @@ impl ProgrammmableTone {
         res
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ToneType {
     SpeakerOn,
     SpeakerOff,
@@ -340,7 +340,7 @@ pub enum ToneType {
     StoreProgrammableSound,
     TriggerProgrammableSound,
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct GenerateSpeakerTone {
     pub tone_type: ToneType,
 }

--- a/alpha_sign/src/write_special.rs
+++ b/alpha_sign/src/write_special.rs
@@ -1,4 +1,8 @@
 use time::Time;
+
+use crate::ParseInput;
+use crate::ParseResult;
+
 #[derive(Debug)]
 pub enum WriteSpecial {
     SetTime(SetTime),
@@ -30,6 +34,10 @@ impl WriteSpecial {
         };
         res.append(&mut inner);
         res
+    }
+
+    pub fn parse(input: ParseInput) -> ParseResult<Self> {
+        todo!()
     }
 }
 #[derive(Debug)]

--- a/alpha_sign/src/write_special.rs
+++ b/alpha_sign/src/write_special.rs
@@ -6,6 +6,7 @@ use nom::character::complete::one_of;
 use nom::combinator::map;
 use nom::combinator::map_res;
 use nom::combinator::opt;
+use nom::combinator::value;
 use nom::multi::count;
 use nom::sequence::delimited;
 use nom::sequence::pair;
@@ -160,7 +161,15 @@ impl ToggleSpeaker {
         res
     }
     fn parse(input: ParseInput) -> ParseResult<Self> {
-        todo!()
+        let (remain, parse) = preceded(
+            char(0x21.into()),
+            alt((
+                value(true, tag([0x30, 0x30])),
+                value(false, tag([0x46, 0x46])),
+            )),
+        )(input)?;
+
+        Ok((remain, ToggleSpeaker::new(parse)))
     }
 }
 #[derive(Debug, PartialEq, Eq)]

--- a/alpha_sign/src/write_special.rs
+++ b/alpha_sign/src/write_special.rs
@@ -1,5 +1,5 @@
 use time::Time;
-
+#[derive(Debug)]
 pub enum WriteSpecial {
     SetTime(SetTime),
     ToggleSpeaker(ToggleSpeaker),
@@ -32,7 +32,7 @@ impl WriteSpecial {
         res
     }
 }
-
+#[derive(Debug)]
 pub struct SetTime {
     pub time: Time,
 }
@@ -53,7 +53,7 @@ impl SetTime {
         res
     }
 }
-
+#[derive(Debug)]
 pub struct ToggleSpeaker {
     pub enabled: bool,
 }
@@ -77,13 +77,13 @@ impl ToggleSpeaker {
         res
     }
 }
-
+#[derive(Debug)]
 pub enum ColorStatus {
     Monochrome,
     Tricolor,
     Octocolor,
 }
-
+#[derive(Debug)]
 pub struct StartStopTime {
     time: Time,
 }
@@ -98,7 +98,7 @@ impl StartStopTime {
         self.time
     }
 }
-
+#[derive(Debug)]
 pub enum OnPeriod {
     Always,
     Never,
@@ -126,13 +126,13 @@ impl OnPeriod {
         format!("{start:0<2X}{end:0<2X}", start = res[0], end = res[1]).into_bytes()
     }
 }
-
+#[derive(Debug)]
 pub enum FileType {
     Text { on_period: OnPeriod },
     String,
     Dots { color_status: ColorStatus },
 }
-
+#[derive(Debug)]
 pub struct MemoryConfiguration {
     pub label: char,
     pub file_type: FileType,
@@ -177,7 +177,7 @@ impl MemoryConfiguration {
         res
     }
 }
-
+#[derive(Debug)]
 pub struct ConfigureMemory {
     pub configurations: Vec<MemoryConfiguration>,
 }
@@ -199,7 +199,7 @@ impl ConfigureMemory {
         res
     }
 }
-
+#[derive(Debug)]
 pub struct ClearMemoryAndFlash {}
 
 impl ClearMemoryAndFlash {
@@ -213,7 +213,7 @@ impl ClearMemoryAndFlash {
         Self::SPECIAL_LABEL.into()
     }
 }
-
+#[derive(Debug)]
 pub struct SetDayOfWeek {
     pub day: time::Weekday,
 }
@@ -240,7 +240,7 @@ impl SetDayOfWeek {
         res
     }
 }
-
+#[derive(Debug)]
 pub struct SetTimeFormat {
     pub twenty_four_hour: bool,
 }
@@ -268,9 +268,9 @@ impl SetTimeFormat {
 pub enum ToneError {
     DurationOutOfRange,
     RepeatsOutOfRange,
-    FrequencyOutOfRange
+    FrequencyOutOfRange,
 }
-
+#[derive(Debug)]
 pub struct ProgrammmableTone {
     frequency: u8,
     duration: u8,
@@ -281,7 +281,7 @@ impl ProgrammmableTone {
     pub fn new(frequency: u8, duration: u8, repeats: u8) -> Result<Self, ToneError> {
         if frequency > 0xFE {
             Err(ToneError::FrequencyOutOfRange)
-        }else if duration > 0xF {
+        } else if duration > 0xF {
             Err(ToneError::DurationOutOfRange)
         } else if repeats > 0xF {
             Err(ToneError::RepeatsOutOfRange)
@@ -298,7 +298,7 @@ impl ProgrammmableTone {
         self.frequency
     }
 
-    pub fn duration(&self) -> u8  {
+    pub fn duration(&self) -> u8 {
         self.duration
     }
 
@@ -320,7 +320,7 @@ impl ProgrammmableTone {
         res
     }
 }
-
+#[derive(Debug)]
 pub enum ToneType {
     SpeakerOn,
     SpeakerOff,
@@ -332,7 +332,7 @@ pub enum ToneType {
     StoreProgrammableSound,
     TriggerProgrammableSound,
 }
-
+#[derive(Debug)]
 pub struct GenerateSpeakerTone {
     pub tone_type: ToneType,
 }

--- a/alpha_sign/tests/parse_tests.rs
+++ b/alpha_sign/tests/parse_tests.rs
@@ -1,0 +1,79 @@
+use alpha_sign::text::ReadText;
+use alpha_sign::text::WriteText;
+use alpha_sign::Command;
+use alpha_sign::Packet;
+use alpha_sign::SignSelector;
+
+#[test]
+fn test_parse_writeText() {
+    let pkt = Packet::new(
+        vec![SignSelector::default()],
+        vec![Command::WriteText(WriteText::new('A', "test".to_string()))],
+    );
+
+    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
+}
+
+#[test]
+fn test_parse_multiple_selectors() {
+    let pkt = Packet::new(
+        vec![
+            SignSelector::default(),
+            SignSelector {
+                sign_type: alpha_sign::SignType::All,
+                address: 0x69,
+            },
+        ],
+        vec![Command::WriteText(WriteText::new('A', "test".to_string()))],
+    );
+
+    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
+}
+
+#[test]
+fn test_parse_multiple_commands() {
+    let pkt = Packet::new(
+        vec![SignSelector::default()],
+        vec![
+            Command::WriteText(WriteText::new('A', "test".to_string())),
+            Command::WriteText(WriteText::new('B', "test 2".to_string())),
+        ],
+    );
+
+    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
+}
+
+#[test]
+fn test_parse_multiple_commands_and_selectors() {
+    let pkt = Packet::new(
+        vec![
+            SignSelector::default(),
+            SignSelector {
+                sign_type: alpha_sign::SignType::All,
+                address: 0x69,
+            },
+        ],
+        vec![
+            Command::WriteText(WriteText::new('A', "test".to_string())),
+            Command::WriteText(WriteText::new('B', "test 2".to_string())),
+        ],
+    );
+
+    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
+}

--- a/alpha_sign/tests/parse_tests.rs
+++ b/alpha_sign/tests/parse_tests.rs
@@ -69,6 +69,23 @@ fn test_parse_multiple_commands() {
 }
 
 #[test]
+fn test_parse_multiple_different_commands() {
+    let pkt = Packet::new(
+        vec![SignSelector::default()],
+        vec![
+            Command::WriteText(WriteText::new('A', "test".to_string())),
+            Command::ReadText(ReadText::new('D')),
+        ],
+    );
+
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
+}
+
+#[test]
 fn test_parse_multiple_commands_and_selectors() {
     let pkt = Packet::new(
         vec![

--- a/alpha_sign/tests/parse_tests.rs
+++ b/alpha_sign/tests/parse_tests.rs
@@ -5,17 +5,30 @@ use alpha_sign::Packet;
 use alpha_sign::SignSelector;
 
 #[test]
-fn test_parse_writeText() {
+fn test_parse_write_text() {
     let pkt = Packet::new(
         vec![SignSelector::default()],
         vec![Command::WriteText(WriteText::new('A', "test".to_string()))],
     );
 
-    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
         panic!()
     };
 
     assert_eq!(res, pkt)
+}
+
+#[test]
+fn test_parse_read_text() {
+    let pkt = Packet::new(
+        vec![SignSelector::default()],
+        vec![Command::ReadText(ReadText::new('A'))],
+    );
+
+    match Packet::parse(pkt.encode().unwrap().as_slice()) {
+        Ok((_, res)) => assert_eq!(pkt, res),
+        Err(e) => println!("{:#?}", e),
+    };
 }
 
 #[test]
@@ -31,7 +44,7 @@ fn test_parse_multiple_selectors() {
         vec![Command::WriteText(WriteText::new('A', "test".to_string()))],
     );
 
-    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
         panic!()
     };
 
@@ -48,7 +61,7 @@ fn test_parse_multiple_commands() {
         ],
     );
 
-    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
         panic!()
     };
 
@@ -71,7 +84,7 @@ fn test_parse_multiple_commands_and_selectors() {
         ],
     );
 
-    let Ok((leftover, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
         panic!()
     };
 

--- a/alpha_sign/tests/parse_tests.rs
+++ b/alpha_sign/tests/parse_tests.rs
@@ -1,8 +1,12 @@
 use alpha_sign::text::ReadText;
 use alpha_sign::text::WriteText;
+use alpha_sign::write_special::SetTime;
+use alpha_sign::write_special::WriteSpecial;
 use alpha_sign::Command;
 use alpha_sign::Packet;
 use alpha_sign::SignSelector;
+use time;
+use time::Time;
 
 #[test]
 fn test_parse_write_text() {
@@ -29,6 +33,22 @@ fn test_parse_read_text() {
         Ok((_, res)) => assert_eq!(pkt, res),
         Err(e) => println!("{:#?}", e),
     };
+}
+
+#[test]
+fn test_parse_set_time() {
+    let pkt = Packet::new(
+        vec![SignSelector::default()],
+        vec![Command::WriteSpecial(WriteSpecial::SetTime(SetTime::new(
+            Time::from_hms(12, 30, 0).unwrap(),
+        )))],
+    );
+
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
 }
 
 #[test]

--- a/alpha_sign/tests/parse_tests.rs
+++ b/alpha_sign/tests/parse_tests.rs
@@ -1,6 +1,7 @@
 use alpha_sign::text::ReadText;
 use alpha_sign::text::WriteText;
 use alpha_sign::write_special::SetTime;
+use alpha_sign::write_special::ToggleSpeaker;
 use alpha_sign::write_special::WriteSpecial;
 use alpha_sign::Command;
 use alpha_sign::Packet;
@@ -42,6 +43,38 @@ fn test_parse_set_time() {
         vec![Command::WriteSpecial(WriteSpecial::SetTime(SetTime::new(
             Time::from_hms(12, 30, 0).unwrap(),
         )))],
+    );
+
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
+}
+
+#[test]
+fn test_parse_toggle_speaker_on() {
+    let pkt = Packet::new(
+        vec![SignSelector::default()],
+        vec![Command::WriteSpecial(WriteSpecial::ToggleSpeaker(
+            ToggleSpeaker::new(true),
+        ))],
+    );
+
+    let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {
+        panic!()
+    };
+
+    assert_eq!(res, pkt)
+}
+
+#[test]
+fn test_parse_toggle_speaker_off() {
+    let pkt = Packet::new(
+        vec![SignSelector::default()],
+        vec![Command::WriteSpecial(WriteSpecial::ToggleSpeaker(
+            ToggleSpeaker::new(false),
+        ))],
     );
 
     let Ok((_, res)) = Packet::parse(pkt.encode().unwrap().as_slice()) else {


### PR DESCRIPTION
So this is merging my branch on which I have added parsers for ReadText and WriteText commands and the general packet format, and added an endpoint to the API for reading text from the sign. The API code is a bit messy but we can clean it later, and implementing the WriteSpecial parsers makes sense once #6 is also merged. 

